### PR TITLE
[25기 김동휘] Add: 소셜로그인 구현

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -7,6 +7,7 @@ import Main from './pages/Main/Main';
 import Lecture from './pages/Lecture/Lecture';
 import Courses from './pages/Courses/Courses';
 import Course from './pages/Course/Course';
+import KakaoRedirect from './pages/Login/KakaoRedirect';
 
 class Routes extends React.Component {
   render() {
@@ -20,6 +21,7 @@ class Routes extends React.Component {
           <Route exact path="/lecture" component={Lecture} />
           <Route exact path="/course" component={Course} /> {/* 상세페이지 */}
           <Route exact path="/courses" component={Courses} />
+          <Route exact path="/oauth/callback/kakao" component={KakaoRedirect} />
           {/* 강의 리스트 */}
         </Switch>
       </Router>

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const BACKEND_TOKEN_URL = 'http://10.58.5.115:8000/users/login';

--- a/src/pages/Login/KakaoRedirect.js
+++ b/src/pages/Login/KakaoRedirect.js
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import { BACKEND_TOKEN_URL } from '../../config';
+
+export default function KakaoRedirect() {
+  const history = useHistory();
+
+  useEffect(() => {
+    const kakaoCode = new URL(window.location.href).searchParams.get('code');
+    fetch(
+      `https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id=${process.env.REACT_APP_CLIENT_ID}&redirect_uri=http://localhost:3000/oauth/callback/kakao&code=${kakaoCode}`
+    )
+      .then(res => res.json())
+      .then(res => {
+        fetch(BACKEND_TOKEN_URL, {
+          headers: {
+            Authorization: res.access_token,
+          },
+        })
+          .then(res => res.json())
+          .then(data => {
+            localStorage.setItem('token', data.access_token);
+            history.push('/');
+          });
+      });
+  }, [history]);
+
+  return <div />;
+}

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { KAKAO_AUTH_URL } from './OAuth';
 import styled from 'styled-components';
 
 export default function Login() {
@@ -23,11 +24,15 @@ export default function Login() {
         <div />
         <h5>간편 로그인</h5>
       </EasyLogin>
-
-      <Button kakao>
-        <img alt="kakaoLogo" src="https://repickus.com/images/btn_kakao.png" />
-        카카오톡 로그인
-      </Button>
+      <a href={KAKAO_AUTH_URL}>
+        <Button kakao>
+          <img
+            alt="kakaoLogo"
+            src="https://repickus.com/images/btn_kakao.png"
+          />
+          카카오톡 로그인
+        </Button>
+      </a>
     </LoginWrapper>
   );
 }

--- a/src/pages/Login/OAuth.js
+++ b/src/pages/Login/OAuth.js
@@ -1,0 +1,4 @@
+const CLIENT_ID = process.env.REACT_APP_CLIENT_ID;
+const REDIRECT_URI = 'http://localhost:3000/oauth/callback/kakao';
+
+export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜로그인 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오톡 로그인 버튼 클릭시 카카오 소셜로그인이 되도록 구현
- 카카오에 인증코드 요청하여 받는다.
- 카카오에서 받은 인증코드를 토큰 요청주소에 query 파라미터로 fetch 통해서 카카오에 access 토큰을 요청해서 받는다.
- 받은 access 토큰을 백엔드에 전달한다.
- 백엔드에서 변환한 사이트 내에서 사용되는 자체 토큰을 받아서 저장하고 메인페이지로 이동한다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 카카오톡 소셜로그인의 전반적인 flow를 이해하는 시간을 가졌다.
- 초반에 인증코드를 받는 것까지는 수월하게 되었는데, 그 이후로 토큰을 요청해서 받는 부분에서 CORS 에러가 났었다. 나중에 알고보니 백엔드와 프론트엔드에서 똑같은 header 객체로 보내주지 않았고(키가 달랐음), 백엔드에서 철자(띄어쓰기)가 안 맞아서 안 되고 있었다. 
- 위에 언급된 blocker를 해결하고 나서는 카카오에서 보내주는 토큰이 유효하지 않다고 카카오에서 백엔드한테 401 에러를 보내줬다. 카카오 developers에서 테스트 해보니 똑같이 401 에러가 나오면서 ip가 맞지 않다고 떴다. 허용 IP 주소에 프론트와 백엔드의 각각의 주소를 넣었으나 그래도 계속 에러가 떴었다. 그러다가 찾아보니 허용 IP 주소를 삭제해보라는 내용을 찾아서 IP 주소를 모두 삭제했더니 성공했다. (아직도 이 부분이 의문이다)
- config와 env 파일을 통해서 필요한 정보를 간략하게 또는 숨김 처리하는 방법을 알게 되었다.

<br />

## :: 기타 질문 및 특이 사항
- 카카오 developers에서 허용 IP 주소를 모두 삭제했더니 해결되었습니다. 그런데 다른 팀은 보니 허용 IP에 프론트와 백엔드 IP 주소를 넣어서 됐다고 하는데.. 이 부분이 명확하게 이해가 되질 않습니다.
